### PR TITLE
formatting as per the traditional ddate utility, including the day number

### DIFF
--- a/ddate.go
+++ b/ddate.go
@@ -17,7 +17,8 @@ const (
 )
 
 func Format(now time.Time) string {
-	return fmt.Sprintf("%s of %s, %d YOLD", dayNames[(now.YearDay()-1)%hailEris%5], seasonNames[(now.YearDay()-1)/hailEris], now.Year()+initialYearPadding)
+	day := now.YearDay() - 1%5
+	return fmt.Sprintf("%s, %s %d, %d YOLD", dayNames[day%hailEris%5], seasonNames[day/hailEris], day+1, now.Year()+initialYearPadding)
 }
 
 func IsHolyday(now time.Time) (bool, string) {

--- a/ddate_test.go
+++ b/ddate_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestFormat(t *testing.T) {
-	want := "Sweetmorn of Chaos, 3136 YOLD"
+	want := "Sweetmorn, Chaos 1, 3136 YOLD"
 	unixStart := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	msg := Format(unixStart)


### PR DESCRIPTION
I rearranged the formatting a bit to include the number of the day and to match the default output of the Unix ddate command. It looks more like this:

Sweetmorn, Chaos 41, 3191 YOLD